### PR TITLE
fix a bug in AddCheckpoints

### DIFF
--- a/CIFAR10_Part1.ipynb
+++ b/CIFAR10_Part1.ipynb
@@ -622,8 +622,8 @@
     "\n",
     "# Add checkpoints to a given model\n",
     "def AddCheckpoints(model, checkpoint_iters, db_type):\n",
-    "    ITER = brew.iter(train_model, \"iter\")\n",
-    "    train_model.Checkpoint([ITER] + train_model.params, [], db=os.path.join(unique_timestamp, \"cifar10_checkpoint_%05d.lmdb\"), db_type=\"lmdb\", every=checkpoint_iters)"
+    "    ITER = brew.iter(model, \"iter\")\n",
+    "    model.Checkpoint([ITER] + model.params, [], db=os.path.join(unique_timestamp, \"cifar10_checkpoint_%05d.lmdb\"), db_type=\"lmdb\", every=checkpoint_iters)"
    ]
   },
   {


### PR DESCRIPTION
 Inside the function of AddCheckpoints, "train_model" should be "model" in terms of consistent name.